### PR TITLE
ヘッダー作成(ログイン後デザインにて)

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,5 +7,6 @@
     background-image: url("top.jpg");
     background-size: cover; /* 画像を画面いっぱいに拡大 */
     background-position: center; /* 画像を中央に配置 */
+    background-attachment: fixed; /* 背景を固定 */
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Myapp</title>
+    <title>DrinkCollection</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -10,7 +10,8 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-neutral-300">
+  <body>
+    <%= render "shared/header" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,8 @@
+<header class="absolute top-0 left-0 w-full text-white z-20">
+  <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+    <!-- ロゴ (常にトップページに遷移)-->
+    <div>
+      <a href="/" class="text-xl font-bold">DrinkCollection</a>
+    </div>
+  </div>
+</header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,35 @@
+<header class="absolute top-0 left-0 w-full text-white z-20">
+  <div class="container mx-auto px-4 py-4 flex items-end justify-between">
+    <!-- ロゴ (常にトップページに遷移)-->
+    <div class="flex items-end space-x-6">
+      <a href="/" class="text-xl font-bold">DrinkCollection</a>
+
+      <!-- ナビゲーション(画面サイズに関わらず常に表示) -->
+      <nav class="flex space-x-4">
+        <a href="#" class="hover:text-gray-300">ビール</a>
+        <a href="#" class="hover:text-gray-300">ワイン</a>
+        <a href="#" class="hover:text-gray-300">日本酒</a>
+        <a href="#" class="hover:text-gray-300">焼酎</a>
+        <a href="#" class="hover:text-gray-300">カクテル</a>
+        <a href="#" class="hover:text-gray-300">etc.</a>
+      </nav>
+    </div>
+
+    <!-- ナビゲーション(画面が大きい場合表示) -->
+    <nav class="hidden md:flex space-x-4">
+      <a href="#" class="hover:text-gray-300" data-turbo-method="delete">投稿作成</a>
+      <a href="#" class="hover:text-gray-300" data-turbo-method="delete">マイページ</a>
+      <a href="#" class="hover:text-gray-300" data-turbo-method="delete">ログアウト</a>
+    </nav>
+
+    <!-- ハンバーガーメニュー(モバイル画面時に適用) -->
+    <div class="md:hidden">
+      <button class="text-white focus:outline-none">
+        <!-- アイコン (Heroiconsを使用) -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
Closes #15 
## 実装内容
- ログイン後のヘッダーを作成
- デザイン⇨お酒の名称を本リリース時にアイコン化する
- app/views/shared/_header.html.erb作成
  - 画面が大きい場合、モバイル画面時対応でコード記述
- app/views/shared/_before_login_header.html.erbはログイン機能作成時に実装
- app/assets/stylesheets/application.tailwind.cssにて
  - `background-attachment: fixed; /* 背景を固定 */`で背景画像を固定、`header class="absolute top-0 left-0 w-full`でヘッダーも固定