### PR TITLE
ログイン・ログアウト機能実装

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,2 +1,20 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+
+  def new; end
+
+  def create
+    @user = login(params[:email], params[:password])
+
+    if @user
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to root_path, status: :see_other
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,11 +2,11 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   # 最低3文字以上必要
-  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:encrypted_password] }
+  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   # password_confirmation と一致すること
-  validates :password, confirmation: true, if: -> { new_record? || changes[:encrypted_password] }
+  validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   # 値が空でないこと（nilや空文字でない）
-  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:encrypted_password] }
+  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   # 値が空でないこと・最大100文字以下であること
   validates :name, presence: true, length: { maximum:100 }
   # 値が空でないこと・ユニークな値であること

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <title>DrinkCollection</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= yield :head %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -12,7 +11,11 @@
   </head>
 
   <body>
-    <%= render "shared/header" %>
+    <% if logged_in? %>
+      <%= render "shared/header" %>
+    <% else %>
+      <%= render "shared/before_login_header" %>
+    <% end %>
     <%= yield %>
     <%= render "shared/footer" %>
   </body>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,8 +1,34 @@
-<header class="absolute top-0 left-0 w-full text-white z-20">
-  <div class="container mx-auto px-4 py-4 flex justify-between items-center">
-    <!-- ロゴ (常にトップページに遷移)-->
-    <div>
-      <a href="/" class="text-xl font-bold">DrinkCollection</a>
+<header class="fixed top-0 left-0 w-full text-black z-20">
+  <div class="container mx-auto px-4 py-4 flex items-end justify-between">
+    <!-- ロゴ (常にトップページに遷移) -->
+    <div class="flex items-end space-x-6">
+      <%= link_to "DrinkCollection", root_path, class: "text-xl font-bold" %>
+
+      <!-- ナビゲーション(画面サイズに関わらず常に表示) -->
+      <nav class="flex space-x-4">
+        <%= link_to "ビール", "#", class: "hover:text-gray-300" %>
+        <%= link_to "ワイン", "#", class: "hover:text-gray-300" %>
+        <%= link_to "日本酒", "#", class: "hover:text-gray-300" %>
+        <%= link_to "焼酎", "#", class: "hover:text-gray-300" %>
+        <%= link_to "カクテル", "#", class: "hover:text-gray-300" %>
+        <%= link_to "etc.", "#", class: "hover:text-gray-300" %>
+      </nav>
+    </div>
+
+    <!-- ナビゲーション(画面が大きい場合表示) -->
+    <nav class="hidden md:flex space-x-4">
+      <%= link_to "新規登録", new_user_path, class: "hover:text-gray-300" %>
+      <%= link_to "ログイン", login_path, class: "hover:text-gray-300" %>
+    </nav>
+
+    <!-- ハンバーガーメニュー(モバイル画面時に適用) -->
+    <div class="md:hidden">
+      <button class="text-black focus:outline-none">
+        <!-- アイコン (Heroiconsを使用) -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
   </div>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,12 +20,12 @@
       <%= link_to "投稿作成", "#", class: "hover:text-gray-300", data: { turbo_method: "delete" } %>
       <%= link_to "投稿一覧", "#", class: "hover:text-gray-300", data: { turbo_method: "delete" } %>
       <%= link_to "マイページ", "#", class: "hover:text-gray-300", data: { turbo_method: "delete" } %>
-      <%= link_to "ログアウト", "#", method: :delete, class: "hover:text-gray-300" %>
+      <%= link_to "ログアウト", logout_path, method: :delete, class: "hover:text-gray-300", data: { turbo_method: "delete" } %>
     </nav>
 
     <!-- ハンバーガーメニュー(モバイル画面時に適用) -->
     <div class="md:hidden">
-      <button class="text-white focus:outline-none">
+      <button class="text-black focus:outline-none">
         <!-- アイコン (Heroiconsを使用) -->
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,0 +1,21 @@
+<!-- ログインレイアウト -->
+<div class="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+  <div class="max-w-md w-full bg-white p-8 shadow-lg rounded-md">
+    <h1 class="text-4xl font-bold text-center mb-6">ログイン</h1>
+    <%= form_with url: login_path, class: "space-y-4" do |form| %>
+      <div class="flex flex-col">
+        <%= form.label :email, "メールアドレス", class: "mb-2 text-sm font-medium text-gray-700" %>
+        <%= form.email_field :email, class: "w-fuu px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500" %>
+      </div>
+      <div class="flex flex-col">
+        <%= form.label :password, "パスワード", class: "mb-2 text-sm font-medium text-gray-700" %>
+        <%= form.password_field :password, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500" %>
+      </div>
+      <%= form.submit "ログイン", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
+    <% end %>
+    <!-- Googleログイン -->
+    <div class="mt-4">
+      <%= link_to "Googleログイン", "#", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,4 @@
-<%= render "shared/header" %>
-
-<!-- ログインレイアウト -->
+<!-- 新規登録レイアウト -->
 <div class="min-h-screen flex items-center justify-center bg-gray-100 px-4">
   <div class="max-w-md w-full bg-white p-8 shadow-lg rounded-md">
     <h1 class="text-4xl font-bold text-center mb-6">新規登録</h1>
@@ -23,7 +21,7 @@
       </div>
       <%= form.submit "新規登録", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
     <% end %>
-    <!-- Googleログイン -->
+    <!-- Google認証 -->
     <div class="mt-4">
       <%= link_to "Google認証", "#", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,10 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
   root "static_pages#top"
+  # ユーザー処理
   resources :users, only: %i[new create show edit update]
-  get "login", to: "user_session#new"
-  post "login", to: "user_session#create"
-  delete "logout", to: "user_session#destroy"
+  # ログインアウト処理
+  get "login", to: "user_sessions#new"
+  post "login", to: "user_sessions#create"
+  delete "logout", to: "user_sessions#destroy"
+  delete "/logout", to: "user_sessions#destroy"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_06_162820) do
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
-    t.string "encrypted_password"
+    t.string "crypted_password"
+    t.string "salt"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Closes #18 
## 実装内容
- 未ログイン時のヘッダー`app/views/shared/_before_login_header.html.erb`を作成
- ログイン機能
  - 未ログイン時のヘッダーに新規登録、ログインボタンの設置
  - ログイン押下後、登録したメールアドレス、パスワードを入力しログイン
  - Googleログインは本リリースにて実装
- ログアウト機能
  - ログイン時のヘッダーのログアウト押下時、未ログイン画面（未ログイン時のヘッダー）に遷移する
- レイアウト・デザインの修正、調整
### 追加・変更したファイル 
[![Image from Gyazo](https://i.gyazo.com/ba39e0a4b5c777048c27b72f4ea0cf84.png)](https://gyazo.com/ba39e0a4b5c777048c27b72f4ea0cf84)