### PR TITLE
記事の投稿機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,4 +2,23 @@ class PostsController < ApplicationController
   def index
     @posts = Post.includes(:user)
   end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      redirect_to posts_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+    private
+
+  def post_params
+    params.require(:post).permit(:title, :body)
+  end
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,18 @@
+<div class="container mx-auto px-4">
+  <div class="max-w-4xl mx-auto">
+    <h1 class="text-2xl font-bold mb-6">投稿作成</h1>
+    <%= form_with model: @post, class: "space-y-6" do |form| %>
+      <div>
+        <%= form.label :title, nil, class: "block text-lg font-medium text-gray-700" %>
+        <%= form.text_field :title, class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+      </div>
+      <div>
+        <%= form.label :body, nil, class: "block text-lg font-medium text-gray-700" %>
+        <%= form.text_area :body, rows: "10", class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+      </div>
+      <div>
+        <%= form.submit "ポスト", class: "inline-flex items-center px-4 py-2 border border-transparent text-lg font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
 
     <!-- ナビゲーション(画面が大きい場合表示) -->
     <nav class="hidden md:flex space-x-4">
-      <%= link_to "投稿作成", "#", class: "hover:text-gray-300" %>
+      <%= link_to "投稿作成", new_post_path, class: "hover:text-gray-300" %>
       <%= link_to "投稿一覧", posts_path, class: "hover:text-gray-300" %>
       <%= link_to "マイページ", "#", class: "hover:text-gray-300" %>
       <%= link_to "ログアウト", logout_path, method: :delete, class: "hover:text-gray-300", data: { turbo_method: "delete" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   root "static_pages#top"
   # ユーザー処理
   resources :users, only: %i[new create show edit update]
-  # 投稿一覧
-  resources :posts, only: %i[index]
+  # 投稿一覧、投稿作成
+  resources :posts, only: %i[index new create]
   # ログインアウト処理
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"


### PR DESCRIPTION
Closes #21 
## 実装内容
- ログイン時、ヘッダーの投稿作成から新規投稿の作成ができる
- 投稿内容（現時点）
  - title
  - body
___
## 実装予定
- 投稿画面のデザイン
- 画像の挿入
- 投稿時のフラッシュメッセージ
- カテゴリ選択
- 投稿内容の題名