### PR TITLE
投稿詳細画面の追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,6 +16,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
     private
 
   def post_params

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,10 +1,16 @@
-<div id="post-id-<%= post.id %>" class="bg-white shadow-md rounded-lg overflow-hidden">
-  <%= image_tag "post_placeholder.png", class: "w-full h-48 object-cover" %>
-  <div class="p-4">
+<div id="post-id-<%= post.id %>" class="bg-white shadow-md rounded-lg overflow-hidden flex">
+  <!-- 画像 -->
+  <div class="w-48 h-48 flex-shrink-0">
+    <%= image_tag "post_placeholder.png", class: "w-48 h-48 object-cover" %>
+  </div>
+  <!-- コンテンツ -->
+  <div class="p-4 flex-1">
     <div class="flex items-center justify-between">
+    <!-- タイトル -->
       <h4 class="text-lg font-bold">
-        <%= link_to post.title, '#', class: "text-gray-800 hover:text-gray-600" %>
+        <%= link_to post.title, post_path(post), class: "text-gray-800 hover:text-gray-600" %>
       </h4>
+      <!-- 編集、削除 -->
       <div class="flex space-x-2">
         <%= link_to '#', id: "button-edit-#{post.id}" do %>
           <i class="bi bi-pencil-fill text-gray-500 hover:text-gray-700"></i>
@@ -14,6 +20,7 @@
         <% end %>
       </div>
     </div>
+    <!-- ユーザー、日付 -->
     <ul class="text-sm text-gray-600 mt-2">
       <li class="flex items-center">
         <i class="bi bi-person mr-2"></i><%= post.user.name %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,31 @@
+<div class="container mx-auto pt-5">
+  <div class="mb-3">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-2xl font-bold mb-5">投稿詳細</h1>
+      <article class="bg-white shadow rounded-lg overflow-hidden flex">
+        <!-- 画像 -->
+        <div class="w-48 h-48 flex-shrink-0">
+          <%= image_tag "post_placeholder.png", class: "w-full h-full object-cover rounded-md" %>
+        </div>
+        <!-- タイトル、詳細情報 -->
+        <div class="p-4 flex-1">
+          <h3 class="text-lg font-semibold mb-2"><%= @post.title %></h3>
+          <ul class="flex text-sm text-gray-600 space-x-4 mb-4">
+            <li><%= "by #{@post.user.name}" %></li>
+            <li><%= l @post.created_at, format: :long %></li>
+          </ul>
+          <div class="flex justify-end space-x-4">
+            <%= link_to "#", id: "button-edit-#{@post.id}", class: "text-blue-500 hover:text-blue-700" do %>
+              <i class="bi bi-pencil-fill"></i>
+            <% end %>
+            <%= link_to "#", id: "button-delete-#{@post.id}", class: "text-red-500 hover:text-red-700" do %>
+              <i class="bi bi-trash-fill"></i>
+            <% end %>
+          </div>
+        </div>
+        <!-- 本文 -->
+        <p class="mt-4 text-gray-700 leading-relaxed"><%= simple_format(@post.body) %></p>
+      </article>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,8 +4,7 @@
 
   <!-- コンテンツ -->
   <div class="relative z-10 text-center">
-    <h1 class="text-4xl font-bold text-blue-500">DrinkCollection</h1>
-    <p class="mt-4 mb-4 text-lg text-gray-700">Build your app with ease!</p>
-    <a href="#" class="mt-6 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Get Started</a>
+    <h1 class="text-4xl font-bold text-orange-950">DrinkCollection</h1>
+    <p class="mt-4 mb-4 text-lg text-gray-700"></p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # ユーザー処理
   resources :users, only: %i[new create show edit update]
   # 投稿一覧、投稿作成
-  resources :posts, only: %i[index new create]
+  resources :posts, only: %i[index new create show]
   # ログインアウト処理
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"


### PR DESCRIPTION
Closes #22 
## 実装内容
- 投稿一覧からtitle（飲み物名）を押下した時、押下した飲み物の詳細画面に遷移
- 詳細画面の作成
## 実装予定
- 編集、削除ボタンの配置
  - tailwindcssに合わせたコーディング、Heroiconsでの挿入→デザイン部分
