### PR TITLE
MVP修正1

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -34,3 +34,5 @@
     </div>
   </div>
 </header>
+
+<div class="pt-16"></div>


### PR DESCRIPTION
## 修正内容
- ヘッダーの高さ分の余白を作成
  - `app/views/shared/_header.html.erb`に`<div class="pt-16"></div>`を追記
  - 投稿一覧や投稿作成時にヘッダーとページ内の文字の重なりを解消
[![Image from Gyazo](https://i.gyazo.com/654cfb2e00c4a20b73a68270b02d8f6b.png)](https://gyazo.com/654cfb2e00c4a20b73a68270b02d8f6b)