### PR TITLE
カテゴリヘッダー変更、各ページスペース調整

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <!-- 画像 -->
   <div class="w-48 h-48 flex-shrink-0">
     <%= link_to post_path(post), class: "block" do %>
-      <%= image_tag post.post_image_url, class: "w-48 h-48 object-cover" %>
+      <%= image_tag post.post_image_url || asset_path('post_placeholder.png'), class: "w-48 h-48 object-cover" %>
     <% end %>
   </div>
   <!-- コンテンツ -->

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,5 @@
-<div class="container mx-auto pt-6">
+<div class="container mx-auto pt-5">
+  <div class="mb-3">
     <!-- 投稿一覧 -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <% if @posts.present? %>
@@ -8,3 +9,4 @@
       <% end %>
     </div>
   </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,8 @@
 <div class="container mx-auto px-4">
-  <div class="max-w-4xl mx-auto">
-    <h1 class="text-2xl font-bold mb-6">投稿作成</h1>
-    <%= render "form", post: @post %> 
+  <div class="mb-3">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-2xl font-bold mb-6">投稿作成</h1>
+      <%= render "form", post: @post %> 
+    </div>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,8 @@
         </div>
         <!-- タイトル、詳細情報 -->
         <div class="p-4 flex-1">
-          <h3 class="text-lg font-semibold mb-2"><%= @post.title %></h3>
+          <div class="flex items-center justify-between">
+            <h3 class="text-lg font-semibold mb-2"><%= @post.title %></h3>
             <% if current_user.own?(@post) %>
               <div class="flex justify-end space-x-4">
                 <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}", class: "text-gray-500 hover:text-gray-700" do %>
@@ -24,13 +25,15 @@
                 <% end %>
               </div>
             <% end %>
+          </div>
+          <!-- 本文 -->
+          <p class="mt-4 text-gray-700 leading-relaxed"><%= simple_format(@post.body) %></p>
+          <!-- ユーザー、日付 -->
           <ul class="flex text-sm text-gray-600 space-x-4 mb-4">
             <li><%= "#{@post.user.name}" %></li>
             <li><%= l @post.created_at, format: :long %></li>
           </ul>
         </div>
-        <!-- 本文 -->
-        <p class="mt-4 text-gray-700 leading-relaxed"><%= simple_format(@post.body) %></p>
       </article>
     </div>
   </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -6,12 +6,26 @@
 
       <!-- ナビゲーション(画面サイズに関わらず常に表示) -->
       <nav class="flex space-x-4">
-        <%= link_to "ビール", category_path("beer"), class: "hover:text-gray-300" %>
-        <%= link_to "ワイン", category_path("wine"), class: "hover:text-gray-300" %>
-        <%= link_to "日本酒", category_path("nihonshu"), class: "hover:text-gray-300" %>
-        <%= link_to "焼酎", category_path("shochu"), class: "hover:text-gray-300" %>
-        <%= link_to "カクテル", category_path("cocktail"), class: "hover:text-gray-300" %>
-        <%= link_to "etc.", category_path("etc"), class: "hover:text-gray-300" %>
+        <%= link_to category_path("beer"), class: "hover:invert" do %>
+          <img src="/assets/beer.png" alt="ビール" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("wine"), class: "hover:invert" do %>
+          <img src="/assets/wine.png" alt="ワイン" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("nihonshu"), class: "hover:invert" do %>
+          <img src="/assets/nihonshu.png" alt="日本酒" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("shochu"), class: "hover:invert" do %>
+          <img src="/assets/shochu.png" alt="焼酎" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("cocktail"), class: "hover:invert" do %>
+          <img src="/assets/cocktail.png" alt="カクテル" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("etc"), class: "hover:invert" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+          </svg>
+        <% end %>
       </nav>
     </div>
 
@@ -32,3 +46,5 @@
     </div>
   </div>
 </header>
+
+<div class="pt-16"></div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,16 +2,30 @@
   <div class="container mx-auto px-4 py-4 flex items-end justify-between">
     <!-- ロゴ (常にトップページに遷移) -->
     <div class="flex items-end space-x-6">
-      <%= link_to "DrinkCollection", root_path, class: "text-xl font-bold" %>
+      <%= link_to "DrinkCollection", root_path, class: "text-2xl font-bold" %>
 
       <!-- ナビゲーション(画面サイズに関わらず常に表示) -->
       <nav class="flex space-x-4">
-        <%= link_to "ビール", category_path("beer"), class: "hover:text-gray-300" %>
-        <%= link_to "ワイン", category_path("wine"), class: "hover:text-gray-300" %>
-        <%= link_to "日本酒", category_path("nihonshu"), class: "hover:text-gray-300" %>
-        <%= link_to "焼酎", category_path("shochu"), class: "hover:text-gray-300" %>
-        <%= link_to "カクテル", category_path("cocktail"), class: "hover:text-gray-300" %>
-        <%= link_to "etc.", category_path("etc"), class: "hover:text-gray-300" %>
+        <%= link_to category_path("beer"), class: "hover:invert" do %>
+          <img src="/assets/beer.png" alt="ビール" class="h-6 w-auto filter brightness-0 ">
+        <% end %>
+        <%= link_to category_path("wine"), class: "hover:invert" do %>
+          <img src="/assets/wine.png" alt="ワイン" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("nihonshu"), class: "hover:invert" do %>
+          <img src="/assets/nihonshu.png" alt="日本酒" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("shochu"), class: "hover:invert" do %>
+          <img src="/assets/shochu.png" alt="焼酎" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("cocktail"), class: "hover:invert" do %>
+          <img src="/assets/cocktail.png" alt="カクテル" class="h-6 w-auto filter brightness-0">
+        <% end %>
+        <%= link_to category_path("etc"), class: "hover:invert" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+          </svg>
+        <% end %>
       </nav>
     </div>
 


### PR DESCRIPTION
## 実装内容
- 各カテゴリのヘッダーをpng画像に変更
[![Image from Gyazo](https://i.gyazo.com/3ff8d00a09b7ca2425a333fcde2243be.png)](https://gyazo.com/3ff8d00a09b7ca2425a333fcde2243be)
- 投稿作成、投稿一覧、投稿詳細のページでフッターとページにスペース作成
  - `<div class="mb-3">`