### PR TITLE
自動ログイン機能の実装

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,9 +4,10 @@ class UserSessionsController < ApplicationController
   def new; end
 
   def create
-    @user = login(params[:email], params[:password])
+    @user = login(params[:email], params[:password], params[:remember_me])
 
     if @user
+      remember_me! if params[:remember_me] == "1" # チェックボックスがオンの時remember_meを有効化
       redirect_to root_path, success: "ログインしました"
     else
       flash.now[:danger] = "ログインに失敗しました"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user) # 新規登録時に自動ログイン
       redirect_to root_path, success: "ユーザー登録が完了しました"
     else
       flash.now[:danger] = "ユーザー登録に失敗しました"

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -11,6 +11,10 @@
         <%= form.label :password, "パスワード", class: "mb-2 text-sm font-medium text-gray-700" %>
         <%= form.password_field :password, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500" %>
       </div>
+      <div class="flex items-center">
+        <%= form.check_box :remember_me, value: "1", class: "mr-2" %>
+        <%= form.label :remember_me, "ログイン状態を保存", class: "text-sm text-gray-700" %>
+      </div>
       <%= form.submit "ログイン", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
     <% end %>
     <!-- Googleログイン -->

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -30,6 +30,7 @@ Rails.application.config.sorcery.configure do |config|
   # Default: `true`
   #
   # config.remember_me_httponly =
+  config.remember_me_token_expires_after = 2.weeks
 
   # Set token randomness. (e.g. user activation tokens)
   # The length of the result string is about 4/3 of `token_randomness`.

--- a/db/migrate/20250216054325_add_remember_me_to_users.rb
+++ b/db/migrate/20250216054325_add_remember_me_to_users.rb
@@ -1,0 +1,6 @@
+class AddRememberMeToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :remember_me_token, :string
+    add_column :users, :remember_me_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_16_183604) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_16_054325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_16_183604) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_admin", default: false, null: false
+    t.string "remember_me_token"
+    t.datetime "remember_me_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
Closes #81 
## 概要
- ログイン時の（次回以降の）自動ログイン機能の実装
- 新規登録時の自動ログイン機能の実装
## 実装内容
- `sorcery`の`remenber_me`を有効化し、ログイン時に次回以降の入力を省くようにした
- `sorcery`の`auto_login`メソッドを使用して、新規登録時に自動でログインされるようにした