### PR TITLE
デプロイエラー対応

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -30,7 +30,6 @@ Rails.application.config.sorcery.configure do |config|
   # Default: `true`
   #
   # config.remember_me_httponly =
-  config.remember_me_token_expires_after = 2.weeks
 
   # Set token randomness. (e.g. user activation tokens)
   # The length of the result string is about 4/3 of `token_randomness`.


### PR DESCRIPTION
## 概要
- デプロイエラー対応
## 実装内容
- 2週間のログイン保持期間設定の削除