### PR TITLE
レイアウト調整３

### DIFF
--- a/app/views/admin/drinks/new.html.erb
+++ b/app/views/admin/drinks/new.html.erb
@@ -1,7 +1,6 @@
-<div class="container mx-auto px-4 bg-amber-50">
-  <div class="mb-3">
-    <div class="max-w-4xl mx-auto">
-      <h1 class="text-2xl font-bold mb-3">新しいドリンクの追加</h1>
+<div class="container">
+    <div class="max-w-4xl mx-auto z-20">
+      <h1 class="text-2xl font-bold mb-3 mt-3">新しいドリンクの追加</h1>
 
       <%= form_with model: @drink, url: admin_drinks_path, local: true do |form| %>
         <div class="mb-4">
@@ -39,5 +38,4 @@
         </div>
       <% end %>
     </div>
-  </div>
 </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -121,20 +121,27 @@
   </div>
 
   <script>
-  document.addEventListener("DOMContentLoaded", function() {
-    document.getElementById("my-posts-tab").addEventListener("click", function() {
-      document.getElementById("my-posts").classList.remove("hidden");
-      document.getElementById("bookmarks").classList.add("hidden");
-      this.classList.add("border-blue-500", "text-black");
-      document.getElementById("bookmarks-tab").classList.remove("border-blue-500", "text-black");
-    });
+    document.addEventListener("turbo:load", function() {
+      const myPostsTab = document.getElementById("my-posts-tab");
+      const bookmarksTab = document.getElementById("bookmarks-tab");
+      const myPosts = document.getElementById("my-posts");
+      const bookmarks = document.getElementById("bookmarks");
 
-    document.getElementById("bookmarks-tab").addEventListener("click", function() {
-      document.getElementById("bookmarks").classList.remove("hidden");
-      document.getElementById("my-posts").classList.add("hidden");
-      this.classList.add("border-blue-500", "text-black");
-      document.getElementById("my-posts-tab").classList.remove("border-blue-500", "text-black");
+      if (myPostsTab && bookmarksTab && myPosts && bookmarks) {
+        myPostsTab.addEventListener("click", function() {
+          myPosts.classList.remove("hidden");
+          bookmarks.classList.add("hidden");
+          this.classList.add("border-blue-500", "text-black");
+          bookmarksTab.classList.remove("border-blue-500", "text-black");
+        });
+
+        bookmarksTab.addEventListener("click", function() {
+          bookmarks.classList.remove("hidden");
+          myPosts.classList.add("hidden");
+          this.classList.add("border-blue-500", "text-black");
+          myPostsTab.classList.remove("border-blue-500", "text-black");
+        });
+      }
     });
-  });
   </script>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <!-- 画像 -->
   <div class="w-48 h-48 flex-shrink-0">
     <%= link_to post_path(post), class: "block" do %>
-      <%= image_tag post.post_image_url, class: "w-48 h-48 object-cover" %>
+      <%= image_tag post.post_image_url.presence || "post_placeholder.png", class: "w-48 h-48 object-cover" %>
     <% end %>
   </div>
   <!-- コンテンツ -->

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,7 @@
 <div class="container mx-auto pt-5">
   <div class="mb-3">
     <!-- 投稿一覧 -->
+    <h1 class="text-2xl font-bold mb-6">投稿一覧</h1>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <% if @posts.present? %>
         <%= render @posts %> 

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -27,57 +27,59 @@
           <!-- 名前検索 -->
           <%= form.text_field :name_or_description_or_mixing_instructions_cont, placeholder: "ドリンク名", class: "search-input px-4 py-2 border border-gray-300 rounded" %>
           <!-- 最低度数のプルダウン -->
-          <%= form.select :alcohol_gteq, options_for_select([["0%以上", 0.0], ["1%以上", 1.0], ["5%以上", 5.0], ["10%以上", 10.0], ["15%以上", 15.0], ["20%以上", 20.0], ["30%以上", 30.0], ["40%以上", 40.0], ["50%以上", 50.0]]), prompt: "最低度数" %>
-          <!-- 最高アルコール度数 -->
-          <%= form.select :alcohol_lteq, options_for_select([["5%以下", 5.0], ["10%以下", 10.0], ["15%以下", 15.0], ["20%以下", 20.0], ["30%以下", 30.0], ["40%以下", 40.0], ["50%以下", 50.0], ["60%以下", 60.0], ["70%以下", 70.0], ["80%以下", 80.0], ["90%以下", 90.0], ["100%以下", 100.0]]), prompt: "最高度数" %>
+          <%= form.select :alcohol_gteq, options_for_select([["0%以上", 0.0], ["1%以上", 1.0], ["5%以上", 5.0], ["10%以上", 10.0], ["15%以上", 15.0], ["20%以上", 20.0], ["30%以上", 30.0], ["40%以上", 40.0], ["50%以上", 50.0]], params.dig(:q, :alcohol_gteq)), prompt: "最低度数" %>
+          <!-- 最高度数のプルダウン -->
+          <%= form.select :alcohol_lteq, options_for_select([["5%以下", 5.0], ["10%以下", 10.0], ["15%以下", 15.0], ["20%以下", 20.0], ["30%以下", 30.0], ["40%以下", 40.0], ["50%以下", 50.0], ["60%以下", 60.0], ["70%以下", 70.0], ["80%以下", 80.0], ["90%以下", 90.0], ["100%以下", 100.0]], params.dig(:q, :alcohol_lteq)), prompt: "最高度数" %>
           <!-- カテゴリー選択 -->
           <%= form.select :category_id_eq, options_for_select(Category.order(:id).map { |c| [c.display_name, c.id] }, selected: params.dig(:q, :category_id_eq)), prompt: "カテゴリー" %>
           <!-- 検索ボタン -->
-          <%= form.submit "検索", class: "search-btn bg-blue-500 hover:bg-blue-700 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
+          <%= form.submit "検索", class: "search-btn bg-indigo-700 hover:bg-gray-700 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
         </div>
       <% end %>
     </div>
 
     <!-- ハンバーガーメニュー (画面サイズに関係なく適用) -->
-<div class="relative">
-  <button id="menu-toggle" class="text-black focus:outline-none">
-    <!-- アイコン (Heroiconsを使用) -->
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-    </svg>
-  </button>
+    <div class="relative">
+      <button id="menu-toggle" class="text-black focus:outline-none">
+        <!-- アイコン (Heroiconsを使用) -->
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
 
-  <!-- メニュー内容 (デフォルトでは非表示) -->
-  <nav id="menu" class="absolute left-0 mt-2 w-48 bg-white border border-gray-300 rounded-lg shadow-lg hidden">
-    <ul class="flex flex-col space-y-2 p-2">
-      <li class="px-4 py-2">
-        <%= link_to "新規登録", new_user_path, class: "block text-black hover:bg-gray-100 rounded" %>
-      </li>
-      <li class="px-4 py-2">
-        <%= link_to t("header.login"), login_path, class: "block text-black hover:bg-gray-100 rounded" %>
-      </li>
-    </ul>
-  </nav>
-</div>
+      <!-- メニュー内容 (デフォルトでは非表示) -->
+      <nav id="menu" class="absolute left-0 mt-2 w-48 bg-white border border-gray-300 rounded-lg shadow-lg hidden">
+        <ul class="flex flex-col space-y-2 p-2">
+          <li class="px-4 py-2">
+            <%= link_to "新規登録", new_user_path, class: "block text-black hover:bg-gray-100 rounded" %>
+          </li>
+          <li class="px-4 py-2">
+            <%= link_to t("header.login"), login_path, class: "block text-black hover:bg-gray-100 rounded" %>
+          </li>
+        </ul>
+      </nav>
+    </div>
 
-<!-- ハンバーガーメニューの開閉を制御するJavaScript -->
-<script>
-  document.addEventListener("DOMContentLoaded", function() {
-    const menuToggle = document.getElementById("menu-toggle");
-    const menu = document.getElementById("menu");
+    <!-- ハンバーガーメニューの開閉を制御するJavaScript -->
+    <script>
+      document.addEventListener("turbo:load", function() {
+        const menuToggle = document.getElementById("menu-toggle");
+        const menu = document.getElementById("menu");
 
-    menuToggle.addEventListener("click", function() {
-      menu.classList.toggle("hidden");
-    });
+        if (menuToggle && menu) {
+          menuToggle.addEventListener("click", function() {
+            menu.classList.toggle("hidden");
+          });
 
-    // メニュー外をクリックすると閉じる
-    document.addEventListener("click", function(event) {
-      if (!menu.contains(event.target) && !menuToggle.contains(event.target)) {
-        menu.classList.add("hidden");
-      }
-    });
-  });
-</script>
+          // メニュー外をクリックすると閉じる
+          document.addEventListener("click", function(event) {
+            if (!menu.contains(event.target) && !menuToggle.contains(event.target)) {
+              menu.classList.add("hidden");
+            }
+          });
+        }
+      });
+    </script>
   </div>
 </header>
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div id="error_explanation" class="bg-red-100 border border-red-400 text-red-700 p-4 rounded-lg">
+  <div id="error_explanation" class="bg-red-100 border border-red-400 text-red-700 p-4">
     <ul class="list-disc pl-5">
       <% object.errors.each do |error| %>
         <li><%= error.full_message %></li>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,6 @@
 <!-- フラッシュメッセージ -->
 <% flash.each do |message_type, message| %>
-  <div class="p-4 mb-4 text-sm text-white rounded-lg 
+  <div class="p-4 mb-4 text-sm text-white
     <%= message_type == 'success' ? 'bg-green-500' : 'bg-red-500' %>">
     <%= message %>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="pt-16"></div>
 <header class="fixed top-0 left-0 w-full bg-amber-300 text-black z-20">
-  <div class="container mx-auto px-4 py-4 flex items-end justify-between">
+  <div class="container mx-auto px-4 py-4 flex items-center justify-between">
     <!-- ロゴ (常にトップページに遷移) -->
     <div class="flex items-end space-x-6">
       <%= link_to "DrinkCollection", root_path, class: "text-2xl font-bold" %>
@@ -27,13 +27,13 @@
           <!-- 名前検索 -->
           <%= form.text_field :name_or_description_or_mixing_instructions_cont, placeholder: "ドリンク名", class: "search-input px-4 py-2 border border-gray-300 rounded" %>
           <!-- 最低度数のプルダウン -->
-          <%= form.select :alcohol_gteq, options_for_select([["0%以上", 0.0], ["1%以上", 1.0], ["5%以上", 5.0], ["10%以上", 10.0], ["15%以上", 15.0], ["20%以上", 20.0], ["30%以上", 30.0], ["40%以上", 40.0], ["50%以上", 50.0]]), prompt: "最低度数", class: "py-2 border border-gray-300 rounded h-12" %>
-          <!-- 最高アルコール度数 -->
-          <%= form.select :alcohol_lteq, options_for_select([["5%以下", 5.0], ["10%以下", 10.0], ["15%以下", 15.0], ["20%以下", 20.0], ["30%以下", 30.0], ["40%以下", 40.0], ["50%以下", 50.0], ["60%以下", 60.0], ["70%以下", 70.0], ["80%以下", 80.0], ["90%以下", 90.0], ["100%以下", 100.0]]), prompt: "最高度数", class: "py-2 border border-gray-300 rounded h-12" %>
+          <%= form.select :alcohol_gteq, options_for_select([["0%以上", 0.0], ["1%以上", 1.0], ["5%以上", 5.0], ["10%以上", 10.0], ["15%以上", 15.0], ["20%以上", 20.0], ["30%以上", 30.0], ["40%以上", 40.0], ["50%以上", 50.0]], params.dig(:q, :alcohol_gteq)), prompt: "最低度数" %>
+          <!-- 最高度数のプルダウン -->
+          <%= form.select :alcohol_lteq, options_for_select([["5%以下", 5.0], ["10%以下", 10.0], ["15%以下", 15.0], ["20%以下", 20.0], ["30%以下", 30.0], ["40%以下", 40.0], ["50%以下", 50.0], ["60%以下", 60.0], ["70%以下", 70.0], ["80%以下", 80.0], ["90%以下", 90.0], ["100%以下", 100.0]], params.dig(:q, :alcohol_lteq)), prompt: "最高度数" %>
           <!-- カテゴリー選択 -->
-          <%= form.select :category_id_eq, options_for_select(Category.order(:id).map { |c| [c.display_name, c.id] }, selected: params.dig(:q, :category_id_eq)), prompt: "カテゴリー", class: "py-2 border border-gray-300 rounded h-12" %>
+          <%= form.select :category_id_eq, options_for_select(Category.order(:id).map { |c| [c.display_name, c.id] }, selected: params.dig(:q, :category_id_eq)), prompt: "カテゴリー" %>
           <!-- 検索ボタン -->
-          <%= form.submit "検索", class: "search-btn bg-blue-500 hover:bg-gray-700 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
+          <%= form.submit "検索", class: "search-btn bg-indigo-700 hover:bg-gray-700 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
         </div>
       <% end %>
     </div>
@@ -60,20 +60,22 @@
 
     <!-- ハンバーガーメニューの開閉を制御するJavaScript -->
     <script>
-      document.addEventListener("DOMContentLoaded", function() {
+      document.addEventListener("turbo:load", function() {
         const menuToggle = document.getElementById("menu-toggle");
         const menu = document.getElementById("menu");
 
-        menuToggle.addEventListener("click", function() {
-          menu.classList.toggle("hidden");
-        });
+        if (menuToggle && menu) {
+          menuToggle.addEventListener("click", function() {
+            menu.classList.toggle("hidden");
+          });
 
-        // メニュー外をクリックすると閉じる
-        document.addEventListener("click", function(event) {
-          if (!menu.contains(event.target) && !menuToggle.contains(event.target)) {
-            menu.classList.add("hidden");
-          }
-        });
+          // メニュー外をクリックすると閉じる
+          document.addEventListener("click", function(event) {
+            if (!menu.contains(event.target) && !menuToggle.contains(event.target)) {
+              menu.classList.add("hidden");
+            }
+          });
+        }
       });
     </script>
   </div>


### PR DESCRIPTION
##実装内容
- 管理者専用ページ内レイアウト調整
- マイページのタブ切り替え動作、ヘッダーのハンバーガーメニューの開閉動作調整
- フラッシュメッセージ表示時のレイアウト調整
- 投稿一覧表示時のタイトル(投稿一覧)追加
- 本番環境での投稿画像がない場合のエラー対応
  - 1.画像がない場合に`assets/images/`より参照される方法を試行
- ヘッダー検索フォームプルダウンを選択して検索した時の選択状態を保持する設定追加