### PR TITLE
レイアウト調整４

### DIFF
--- a/app/views/admin/drinks/new.html.erb
+++ b/app/views/admin/drinks/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-    <div class="max-w-4xl mx-auto z-20">
+    <div class="max-w-4xl mx-auto mt-3 z-20">
       <h1 class="text-2xl font-bold mb-3 mt-3">新しいドリンクの追加</h1>
 
       <%= form_with model: @drink, url: admin_drinks_path, local: true do |form| %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <!-- 画像 -->
   <div class="w-48 h-48 flex-shrink-0">
     <%= link_to post_path(post), class: "block" do %>
-      <%= image_tag post.post_image_url.presence || "post_placeholder.png", class: "w-48 h-48 object-cover" %>
+      <%= image_tag post.post_image_url.presence || asset_path("post_placeholder.png"), class: "w-48 h-48 object-cover" %>
     <% end %>
   </div>
   <!-- コンテンツ -->

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container mx-auto px-4">
+<div class="container mx-auto pt-5">
   <div class="mb-3">
     <div class="max-w-4xl mx-auto">
       <h1 class="text-2xl font-bold mb-6">投稿作成</h1>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -33,7 +33,7 @@
           <!-- カテゴリー選択 -->
           <%= form.select :category_id_eq, options_for_select(Category.order(:id).map { |c| [c.display_name, c.id] }, selected: params.dig(:q, :category_id_eq)), prompt: "カテゴリー" %>
           <!-- 検索ボタン -->
-          <%= form.submit "検索", class: "search-btn bg-indigo-700 hover:bg-gray-700 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
+          <%= form.submit "検索", class: "search-btn bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
         </div>
       <% end %>
     </div>
@@ -48,7 +48,7 @@
       </button>
 
       <!-- メニュー内容 (デフォルトでは非表示) -->
-      <nav id="menu" class="absolute left-0 mt-2 w-48 bg-white border border-gray-300 rounded-lg shadow-lg hidden">
+      <nav id="menu" class="absolute right-0 mt-2 w-48 bg-white border border-gray-300 rounded-lg shadow-lg hidden">
         <ul class="flex flex-col space-y-2 p-2">
           <li><%= link_to t("header.create_post"), new_post_path, class: "block px-4 py-2 hover:bg-gray-200" %></li>
           <li><%= link_to t("header.post_index"), posts_path, class: "block px-4 py-2 hover:bg-gray-200" %></li>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -16,12 +16,20 @@
         <%= form.label :remember_me, "ログイン状態を保存", class: "text-sm text-gray-700" %>
       </div>
       <div class="text-center">
-        <%= form.submit "ログイン", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
+        <%= form.submit "ログイン", class: "btn-center mb-4 bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-4 rounded" %>
       </div>
     <% end %>
+    <div class="flex items-center my-4">
+      <div class="flex-1 border-t border-gray-300"></div>
+      <span class="px-3 text-gray-500 text-sm">OR</span>
+      <div class="flex-1 border-t border-gray-300"></div>
+    </div>
     <!-- Googleログイン -->
     <div class="mt-4 flex justify-center">
-      <%= link_to "Login with Google", "/auth/google_oauth2", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
+      <%= link_to "/auth/google_oauth2", class: "flex text-center items-center bg-white border border-gray-300 rounded-md px-4 py-2 shadow-sm hover:shadow-md focus:outline-none" do %>
+        <%= image_tag "https://developers.google.com/identity/images/g-logo.png", alt: "Google logo", class: "w-6 h-6 mr-2" %>
+        <span class="text-gray-700 font-medium">Sign in with Google</span>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -21,12 +21,20 @@
         <%= form.password_field :password_confirmation, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500" %>
       </div>
       <div class="text-center">
-        <%= form.submit "新規登録", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
+        <%= form.submit "新規登録", class: "btn-center mb-4 bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-4 rounded" %>
       </div>
     <% end %>
+    <div class="flex items-center my-4">
+      <div class="flex-1 border-t border-gray-300"></div>
+      <span class="px-3 text-gray-500 text-sm">OR</span>
+      <div class="flex-1 border-t border-gray-300"></div>
+    </div>
     <!-- Google認証 -->
-    <div class="mt-4 text-center">
-      <%= link_to "Login with Google", "/auth/google_oauth2", class: "btn-center mb-4 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded" %>
+    <div class="mt-4 flex justify-center">
+      <%= link_to "/auth/google_oauth2", class: "flex items-center bg-white border border-gray-300 rounded-md px-4 py-2 shadow-sm hover:shadow-md focus:outline-none" do %>
+        <%= image_tag "https://developers.google.com/identity/images/g-logo.png", alt: "Google logo", class: "w-6 h-6 mr-2" %>
+        <span class="text-gray-700 font-medium">Sign in with Google</span>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,4 @@ Rails.application.config.assets.version = "1.0"
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[post_placeholder.png]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": true,
   "devDependencies": {
-    "esbuild": "^0.24.0"
+
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
@@ -14,6 +14,7 @@
     "autoprefixer": "^10.4.20",
     "daisyui": "^4.12.14",
     "postcss": "^8.4.49",
-    "tailwindcss": "^3.4.15"
+    "tailwindcss": "^3.4.15",
+    "esbuild": "^0.24.0"
   }
 }


### PR DESCRIPTION
## 実装内容
- 新規登録、ログイン時のGoogleログインを公式SVG仕様に変更
- 本番環境で投稿画像がない場合のエラー対応
  - 2.`config/initializers/assets.rb`に`Rails.application.config.assets.precompile += %w[post_placeholder.png]`を明記
  - 本番環境の`app/assets/images/`にも画像はあるが認識されないため