### PR TITLE
エラー対応１

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <!-- 画像 -->
   <div class="w-48 h-48 flex-shrink-0">
     <%= link_to post_path(post), class: "block" do %>
-      <%= image_tag post.post_image_url.presence || asset_path("post_placeholder.png"), class: "w-48 h-48 object-cover" %>
+      <%= image_tag post.post_image_url.presence || image_path("post_placeholder.png"), class: "w-48 h-48 object-cover" %>
     <% end %>
   </div>
   <!-- コンテンツ -->

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## 実装内容
- `config/environments/production.rb`の`config.assets.compile = false`を`true`に修正
- `app/views/posts/_post.html.erb`の`<%= image_tag post.post_image_url.presence || image_path("post_placeholder.png"), class: "w-48 h-48 object-cover" %>`を本番環境用に修正