### PR TITLE
写真保存設定

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <!-- 画像 -->
   <div class="w-48 h-48 flex-shrink-0">
     <%= link_to post_path(post), class: "block" do %>
-      <%= image_tag post.post_image_url.presence || image_path("post_placeholder.png"), class: "w-48 h-48 object-cover" %>
+      <%= image_tag (post.post_image.url if post.post_image.present?) || "/assets/post_placeholder.png", class: "w-48 h-48 object-cover" %>
     <% end %>
   </div>
   <!-- コンテンツ -->


### PR DESCRIPTION
## 実装内容
- Renderの環境変数に`RAILS_SERVE_STATIC_FILES=true` を設定
- `image_tag` の `path` を `asset pipeline` 経由ではなく、S3 のフル URL で取得するよう修正
  - `<%= image_tag (post.post_image.url if post.post_image.present?) || "/assets/post_placeholder.png", class: "w-48 h-48 object-cover" %>
`