### PR TITLE
レイアウト調整５

### DIFF
--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,20 +1,20 @@
 <% content_for(:title, "プロフィール編集") %>
 
 <div class="container mx-auto px-4 py-6">
-  <div class="max-w-2xl mx-auto bg-white p-6 shadow-md rounded-lg">
+  <div class="max-w-2xl mx-auto bg-white p-6 shadow-md rounded-lg text-center">
     <h1 class="text-2xl font-bold mb-4">プロフィール編集</h1>
 
     <%= form_with model: @user, url: mypage_path, method: :put, class: "space-y-4" do |form| %>
       <%= render 'shared/error_messages', object: form.object %>
       <div>
-        <%= form.label :email, class: "block text-lg font-medium text-gray-700" %>
-        <%= form.email_field :email, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm" %>
+        <%= form.label :email, class: "block text-lg font-semibold text-gray-700" %>
+        <%= form.email_field :email, class: "mt-1 block w-full rounded-md border-gray-500 shadow-sm text-center" %>
       </div>
       <div>
-        <%= form.label :ユーザーネーム, class: "block text-lg font-medium text-gray-700" %>
-        <%= form.text_field :name, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm" %>
+        <%= form.label :ユーザーネーム, class: "block text-lg font-semibold text-gray-700" %>
+        <%= form.text_field :name, class: "mt-1 block w-full rounded-md border-gray-400 shadow-sm text-center" %>
       </div>
-      <%= form.submit "更新", class: "inline-block bg-blue-500 hover:bg-blue-700 text-black font-bold py-2 px-4 rounded mb-2" %>
+      <%= form.submit "更新", class: "inline-block bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded mb-2" %>
     <% end %>
     <div class="mt-4 text-center">
       <%= link_to "マイページに戻る", mypage_path, class: "text-blue-500 hover:underline" %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -18,14 +18,14 @@
       </div>
     </div>
     <div class="mt-4 text-center">
-      <%= link_to "編集", edit_mypage_path, class: "inline-block bg-blue-500 hover:bg-blue-700 text-black font-bold py-2 px-4 rounded mb-2" %>
+      <%= link_to "編集", edit_mypage_path, class: "inline-block bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded mb-2" %>
     </div>
   </div>
 
   <!-- タブ切り替えボタン -->
   <div class="mb-5 flex space-x-4 border-b">
-    <button id="my-posts-tab" class="py-2 px-4 border-b-2 border-blue-500 font-bold">自分の投稿</button>
-    <button id="bookmarks-tab" class="py-2 px-4 text-gray-500 font-bold">ブックマーク</button>
+    <button id="my-posts-tab" class="py-2 px-4 border-b-2 border-indigo-600 text-black font-bold">自分の投稿</button>
+    <button id="bookmarks-tab" class="py-2 px-4 border-b-2 border-indigo-600 text-black font-bold">ブックマーク</button>
   </div>
 
   <!-- 投稿一覧 -->

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -33,7 +33,7 @@
           <!-- カテゴリー選択 -->
           <%= form.select :category_id_eq, options_for_select(Category.order(:id).map { |c| [c.display_name, c.id] }, selected: params.dig(:q, :category_id_eq)), prompt: "カテゴリー" %>
           <!-- 検索ボタン -->
-          <%= form.submit "検索", class: "search-btn bg-indigo-600 hover:bg-gray-700 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
+          <%= form.submit "検索", class: "search-btn bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
- 各所レイアウトの調整
## 実装内容
- ログイン前の検索ボタンの色をログイン後と統一
- マイページのプロフィール編集、更新ボタンの色を他のボタンと統一
- マイページのタブの表示スクリプトを修正
  - ブックマークタブ選択時に自分の投稿同様、下線が表示されるよう修正