### PR TITLE
ページネーション、広告配置、レイアウト微調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 gem "ransack"
 gem "meta-tags"
+gem "kaminari"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,18 @@ GEM
     json (2.9.0)
     jwt (2.9.3)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.6)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -372,6 +384,7 @@ DEPENDENCIES
   fog-aws
   jbuilder
   jsbundling-rails
+  kaminari
   meta-tags
   omniauth
   omniauth-google-oauth2

--- a/app/controllers/admin/drinks_controller.rb
+++ b/app/controllers/admin/drinks_controller.rb
@@ -9,7 +9,7 @@ module Admin
     end
 
     def index
-      @drinks = Drink.all
+      @drinks = Drink.all.page(params[:page]).per(20)
       render "drinks/index"
     end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -10,6 +10,7 @@ class CategoriesController < ApplicationController
     @drinks = Drink.where(category: category_name, is_admin: true)
     @bookmark_drinks = current_user&.bookmarked_drinks || []
     @category = Category.find_by(name: params[:category])
+    @categories = Category.page(params[:page]).per(20)
     @drinks = @category.drinks if @category.present?
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :set_ogp, only: [:show]
 
   def index
-    @posts = Post.includes(:user)
+    @posts = Post.includes(:user).page(params[:page]).per(20)
   end
 
   def new

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -70,5 +70,8 @@
         <div class="text-center col-span-full text-gray-600">投稿がありません</div>
       <% end %>
     </div>
+    <div class="mt-6">
+      <%= paginate @categories %>
+    </div>
   </div>
 </div>

--- a/app/views/drinks/index.html.erb
+++ b/app/views/drinks/index.html.erb
@@ -62,5 +62,8 @@
         <% end %>
       <% end %>
     </div>
+    <div class="mt-6">
+      <%= paginate @drinks %>
+    </div>
   </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, "次へ".html_safe, url, class: "join-item btn", rel: 'next', remote: true %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?}", remote: true, rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,23 @@
+<%# The container tag
+- available local variables
+  current_page:  a page object for the currently displayed page
+  total_pages:   total number of pages
+  per_page:      number of items to fetch per page
+  remote:        data-remote
+  paginator:     the paginator that renders the pagination tags inside
+-%>
+<div class="join mt-6 mx-auto flex justify-center">
+  <%= paginator.render do %>
+    <nav class="pagination" role="navigation" aria-label="pager">
+      <%= prev_page_tag unless current_page.first? %>
+        <% each_page do |page| %>
+          <% if page.display_tag? %>
+            <%= page_tag page %>
+          <% end %>
+        <% end %>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  <% end %>
+</div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, "前へ".html_safe, url, class: "join-item btn", rel: 'prev', remote: true %>
+</span>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,12 +3,12 @@
   <!-- タイトル入力 -->
   <div>
     <%= form.label :title, "お酒名", class: "block text-lg font-medium text-gray-700" %>
-    <%= form.text_field :title, placeholder: "30文字以内で入力してください", class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    <%= form.text_field :title, placeholder: "投稿したいお酒を書こう", class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
   </div>
   <!-- 本文入力 -->
   <div>
     <%= form.label :body, "コメント", class: "block text-lg font-medium text-gray-700" %>
-    <%= form.text_area :body, rows: "10", placeholder: "270文字以内で入力してください", class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    <%= form.text_area :body, rows: "10", placeholder: "どんなお酒か教えて！", class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
   </div>
   <!-- 画像アップロード -->
   <div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,5 +9,8 @@
         <div class="text-center col-span-full text-gray-600">投稿がありません</div>
       <% end %>
     </div>
+    <div class="mt-6 text-center">
+      <%= paginate @posts %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,12 +1,12 @@
 <div class="pt-16"></div>
 <header class="fixed top-0 left-0 w-full bg-amber-300 text-black z-20">
-  <div class="container mx-auto px-4 py-4 flex items-end justify-between">
+  <div class="container mx-auto px-4 py-4 flex items-center justify-between">
     <!-- ロゴ (常にトップページに遷移) -->
-    <div class="flex items-end space-x-6">
+    <div class="flex space-x-6">
       <%= link_to "DrinkCollection", root_path, class: "text-2xl font-bold" %>
 
       <!-- ナビゲーション(画面サイズに関わらず常に表示) -->
-      <nav class="flex space-x-4">
+      <nav class="flex mt-1 space-x-4">
         <%= link_to "ビール", category_path("beer"), class: "hover:invert" %>
         <%= link_to "ワイン", category_path("wine"), class: "hover:invert" %>
         <%= link_to "日本酒", category_path("nihonshu"), class: "hover:invert" %>
@@ -39,7 +39,7 @@
     </div>
 
     <!-- ハンバーガーメニュー (画面サイズに関係なく適用) -->
-    <div class="relative">
+    <div class="relative mt-1">
       <button id="menu-toggle" class="text-black focus:outline-none">
         <!-- アイコン (Heroiconsを使用) -->
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,11 +2,11 @@
 <header class="fixed top-0 left-0 w-full bg-amber-300 text-black z-20">
   <div class="container mx-auto px-4 py-4 flex items-center justify-between">
     <!-- ロゴ (常にトップページに遷移) -->
-    <div class="flex items-end space-x-6">
+    <div class="flex space-x-6">
       <%= link_to "DrinkCollection", root_path, class: "text-2xl font-bold" %>
 
       <!-- ナビゲーション(画面サイズに関わらず常に表示) -->
-      <nav class="flex space-x-4">
+      <nav class="flex mt-1 space-x-4">
         <%= link_to "ビール", category_path(Category.find_by(name: "ビール").id), class: "hover:invert" %>
         <%= link_to "ワイン", category_path(Category.find_by(name: "ワイン").id), class: "hover:invert" %>
         <%= link_to "日本酒", category_path(Category.find_by(name: "日本酒").id), class: "hover:invert" %>
@@ -39,7 +39,7 @@
     </div>
 
     <!-- ハンバーガーメニュー (画面サイズに関係なく適用) -->
-    <div class="relative">
+    <div class="relative mt-1">
       <button id="menu-toggle" class="text-black focus:outline-none">
         <!-- アイコン (Heroiconsを使用) -->
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -11,4 +11,15 @@
       雰囲気を楽しみたい方にも、新しいお酒との出会いを提供します。
     </p>
   </div>
+
+  <!-- 広告エリア -->
+  <div class="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-20 opacity-80">
+    <a rel="nofollow" href="https://cl.link-ag.net/click/d11bbf/74049eb4">
+      <img 
+        alt="★友達紹介用★超実践型オンラインプログラミングスクール【RUNTEQ（ランテック）】" 
+        src="https://imps.link-ag.net/imp/d11bbf/74049eb4" 
+        class="max-w-xs h-auto item-center"
+      />
+    </a>
+  </div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 20
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
## 概要
- 投稿ページにページネーションの配置
- トップページに広告の配置
- ヘッダーのレイアウト微調整
## 実装内容
- `gem "kaminari"`を導入し、ページネーションの作成
- トップページに広告の配置（PR未配置、レイアウト未調整）
- ヘッダーのログイン前後のアイコン、文字位置を統一