### PR TITLE
アイコン、メニューのレイアウト調整

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -38,8 +38,8 @@
       <% end %>
     </div>
 
-    <div class="navbar bg-white text-black z-50 relative">
-      <div class="navbar-start">
+    <div class="navbar text-black z-50 relative">
+      <div class="navbar-end">
         <div class="dropdown dropdown-left">
           <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
             <!-- ハンバーガーアイコン -->

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -39,8 +39,8 @@
     </div>
 
     <!-- ハンバーガーメニュー（DaisyUI） -->
-    <div class="navbar bg-white text-black z-50 relative">
-      <div class="navbar-start">
+    <div class="navbar text-black z-50 relative">
+      <div class="navbar-end">
         <div class="dropdown dropdown-left">
           <!-- ハンバーガーアイコン -->
           <div tabindex="0" role="button" class="btn btn-ghost btn-circle">


### PR DESCRIPTION
## 実装内容
- アイコン表示位置をヘッダーの右端に移動
- ヘッダー色に合わせるため`bg-white`を削除