### PR TITLE
ドリンク作成時の遷移先変更

### DIFF
--- a/app/controllers/admin/drinks_controller.rb
+++ b/app/controllers/admin/drinks_controller.rb
@@ -21,7 +21,7 @@ module Admin
       @drink.category = category if category.present?
 
       if @drink.save
-        redirect_to admin_drinks_path, success: "新しいドリンクが追加されました。"
+        redirect_to category_path(@drink.category.name), success: "新しいドリンクが追加されました。"
       else
         flash.now[:alert] = @drink.errors.full_messages.join(", ")
         render :new, status: :unprocessable_entity


### PR DESCRIPTION
## 概要
- 管理者ページからドリンク作成時の遷移先を変更
## 実装内容
- ドリンク作成時検索結果に遷移していた`admin_drink_path`→投稿したカテゴリーページに遷移する`category_path(@drink.category.name)`